### PR TITLE
fix target_temperature_low and target_temperature_high

### DIFF
--- a/gree_lan/water_heater.py
+++ b/gree_lan/water_heater.py
@@ -163,11 +163,11 @@ class GreeWaterHeater(WaterHeaterEntity):
 
     @property
     def target_temperature_low(self):
-        return self.min_temp
+        return None
 
     @property
     def target_temperature_high(self):
-        return self.max_temp
+        return None
 
     @property
     def precision(self):


### PR DESCRIPTION
参照HA的说明，这两个值是对于有明确控温上限和控温下限（不是可以设置的目标温度的上下限）的设备的。根据格力空气能的性质，这里应当返回None，以便HA可以正确的显示当前热水器的设置温度target_temperature。